### PR TITLE
Fix issue authenticating with passwords that have spaces

### DIFF
--- a/synology_srm/http.py
+++ b/synology_srm/http.py
@@ -2,6 +2,7 @@
 
 import os
 import requests
+from urllib.parse import urlencode
 
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
@@ -78,6 +79,9 @@ class Http(object):
 
         self.sid = response['sid']
 
+    def _to_query_string(self, params):
+        return urlencode(params, doseq=True).replace('+', '%20')
+
     def download(self, path, **kwargs):
         """Download a file to the local filesystem from the Synology API."""
         request = self.call(stream=True, **kwargs)
@@ -109,7 +113,7 @@ class Http(object):
         response = requests.get(
             url,
             verify=self.verify,
-            params=params,
+            params=self._to_query_string(params),
             cookies=cookies,
             stream=stream,
         )


### PR DESCRIPTION
The requests library encodes url parameters with spaces using `+` instead of `%20`. SRM does not seem to accept this if a password contains spaces. Encoding spaces using '%20' fixes this.

Passing the query string as a string to the requests library allows you to encode the parameter however you wish.